### PR TITLE
Corrige erreur DynamoDB + test_check3SameComments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea/
+log.out
+spam-should-not-pass.iml
+target/

--- a/src/main/java/net/v4lproik/spamshouldnotpass/platform/client/dynamodb/ConfigDynamoDB.java
+++ b/src/main/java/net/v4lproik/spamshouldnotpass/platform/client/dynamodb/ConfigDynamoDB.java
@@ -5,6 +5,7 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
 import com.amazonaws.services.dynamodbv2.document.DynamoDB;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.annotation.PropertySources;
 import org.springframework.core.env.Environment;
@@ -19,6 +20,7 @@ public class ConfigDynamoDB {
         this.env = env;
     }
 
+    @Bean
     public DynamoDB dynamoDB() {
 
         final String ACCESS_KEY = env.getRequiredProperty("aws.dynamodb.accessKey");

--- a/src/main/java/net/v4lproik/spamshouldnotpass/platform/controllers/ApiController.java
+++ b/src/main/java/net/v4lproik/spamshouldnotpass/platform/controllers/ApiController.java
@@ -170,7 +170,7 @@ public class ApiController {
         Integer nbOfSameCommentsLast5Min = authorInfoRepository.getNumberOfSameDocumentsSubmittedInTheLast5min(userInformation.getOrDefault("email", ""), corporation, userInformation.getOrDefault("content", ""));
 
         userInformation.put(nbDocSubmittedLast5Min, String.valueOf(nbOfCommentsLast5Min));
-        userInformation.put(nbSameDocSubmittedLast5Min, String.valueOf(nbOfCommentsLast5Min));
+        userInformation.put(nbSameDocSubmittedLast5Min, String.valueOf(nbOfSameCommentsLast5Min));
     }
 
     /**


### PR DESCRIPTION
Corrige les erreurs DynamoDB dans les tests : 

> org.springframework.beans.factory.parsing.BeanDefinitionParsingException: Configuration problem: net.v4lproik.spamshouldnotpass.platform.client.dynamodb.ConfigDynamoDB was @Import'ed but is not annotated with @Configuration nor does it declare any @Bean methods; it does not implement ImportSelector or extend ImportBeanDefinitionRegistrar. Update the class to meet one of these requirements or do not attempt to @Import it.

Corrige aussi le test test_check3SameComments dans ApiController
